### PR TITLE
feat(web888): Web-888 receivers, which could not be connected to at all

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -60,7 +60,7 @@ export type RootStackParamList = {
     instanceName?:   string;
     viewMode:        ViewMode;
     serverLongitude?: number | null;
-    serverType?:     'ubersdr' | 'kiwi' | 'owrx';   // v3 multi-backend; default ubersdr
+    serverType?:     'ubersdr' | 'kiwi' | 'web888' | 'owrx';   // v3 multi-backend; default ubersdr
     // NB FM-DX servers route to the 'Tuner' screen instead (see below), not here.
     // V4 local hardware (Android): connect to the on-device shim on localhost.
     // Audio comes from its /ws/audio (external-PCM engine), not the UberSDR /ws.
@@ -265,7 +265,7 @@ export default function App() {
         ? { name: 'Tuner', params: { baseUrl: f.url, instanceName: f.name, viewMode } }
         : { name: 'SDR', params: {
               baseUrl: f.url, instanceName: f.name, viewMode,
-              serverType: (f.serverType ?? 'ubersdr') as 'ubersdr' | 'kiwi' | 'owrx',
+              serverType: (f.serverType ?? 'ubersdr') as 'ubersdr' | 'kiwi' | 'web888' | 'owrx',
               ...(extra ?? {}),
             } };
       // RESET, never navigate() — navigate PUSHES and leaves the old screen mounted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,63 @@ Source: https://github.com/Stuey3D/VibeSDR
 
 ## Unreleased
 
+### Added — Web-888 receivers, which could not be connected to at all
+
+A **Web-888** is a KiwiSDR-compatible receiver, and VibeSDR could not talk to one on either
+existing setting. Picking **KiwiSDR** failed instantly; picking **OpenWebRX** was never going
+to work. Worse, the app then blamed the receiver's owner: the failure looks exactly like a Kiwi
+that only allows its own web page, so VibeSDR told people their own radio was blocking them.
+
+The cause is one string. A Web-888 runs a fork of the KiwiSDR server (RaspSDR) taken before
+upstream moved to a newer web-server API, and that move added a `ws/` marker to the WebSocket
+address so the server could tell a socket from an ordinary page request. The fork never gained
+it, and rejects the address outright — `bad URI_TS format`, and the connection is closed without
+a single byte sent back.
+
+- **Web-888 is now its own choice** in the custom-server box, next to KiwiSDR.
+- **Auto-detect recognises one** from its own branding, so you rarely need to pick it — and the
+  public KiwiSDR directory is read more carefully, so a listed Web-888 is tagged as one.
+- **And it corrects itself anyway.** A receiver that closes the connection having said *nothing*
+  is retried once at the other address. That is the one thing a wrong address looks like and a
+  refusal never does — a receiver has to let you in before it can throw you out — so a genuine
+  refusal is still reported as a refusal, on the first attempt.
+- Every "This KiwiSDR…" message now names the receiver you actually connected to.
+- **And auto-detect works on KiwiSDRs at all now.** Identifying a typed-in address made two
+  requests on one shared five-second budget, and the first — the VibeServer identity check — never
+  returns on a Kiwi: that server does not refuse an unknown address, it simply never answers. The
+  budget was spent before the request that actually identifies the receiver was allowed to start,
+  so every KiwiSDR-family address reported "nothing there" while answering `GET /` in half a
+  second. Each request now has its own timeout.
+
+### Fixed — adding a server by name and port connected to the wrong port
+
+Typing a host into the **+** add-server box and its port into the separate **Port** field found the
+receiver and then refused to connect to it: *"Couldn't connect — connection refused"*. The address
+was parsed without the port, so the port number was right everywhere except in the address actually
+dialled, which fell back to port 80. What disguised it is that everything *else* worked — the
+receiver was correctly identified and saved, and tapping the saved entry connected first time,
+because that path rebuilds the address from the saved host and port.
+
+This was never specific to Web-888; it applied to any receiver added that way. Two changes:
+
+- The address and the port now come out of a single parse, so they cannot disagree. A port written
+  into the host field still wins over the Port box, as before.
+- Probing now reports **which** address answered, and that is the one connected to. Previously the
+  app could identify a receiver at one address and then connect to another — the same latent fault
+  would have sent an https-only receiver on a custom port a plain-http connection.
+
+Also: the Custom URL box on the server list now shows a port in its example
+(`sdr.example.com:8073`). Without one it read as hostname-only, which resolves to port 80 — where
+no receiver listens.
+
+VibeSDR Jr (the watch) gets the same receiver support. It needed it for a reason beyond the new
+hardware: favourites sync between devices, and Jr turned any server type it did not recognise into
+an UberSDR — so a Web-888 saved on the phone would have arrived on the wrist as the wrong kind of
+radio entirely.
+
+Verified against a live Web-888 (`Web888_v2026.609`): audio and waterfall both stream. Checked
+against real KiwiSDRs too, which still connect on the first attempt with no retry.
+
 ### Fixed — the RDS analyser, calibrated against a professional broadcast analyser
 
 With thanks again to **Hans van Eijsden (Zwolle, NL)** of [FMDX.org](https://fmdx.org), who

--- a/spike/WristSDR/WristSDR/InstancePickerView.swift
+++ b/spike/WristSDR/WristSDR/InstancePickerView.swift
@@ -401,7 +401,7 @@ struct InstancePickerView: View {
   // Same server-type logos as the phone picker (bundled PNGs in Logos/). SpyServer + RTL-TCP
   // reuse the rtl_tcp mark. Falls back to a monogram if an image is missing.
   private static let logoName: [ServerType: String] = [
-    .ubersdr: "logo_ubersdr", .kiwi: "logo_kiwi", .owrx: "logo_owrx",
+    .ubersdr: "logo_ubersdr", .kiwi: "logo_kiwi", .web888: "logo_kiwi", .owrx: "logo_owrx",
     .fmdx: "logo_fmdx", .spyserver: "rtltcp", .rtltcp: "rtltcp",
   ]
   @ViewBuilder private func typeBadge(_ t: ServerType) -> some View {

--- a/spike/WristSDR/WristSDR/KiwiClient.swift
+++ b/spike/WristSDR/WristSDR/KiwiClient.swift
@@ -295,8 +295,19 @@ final class KiwiClient: ObservableObject, SDRClient {
   private var rateTimer: Timer?
   private var frameCount = 0
 
-  init(url: String, waterfall: WaterfallBuffer) {
+  /// Which Kiwi dialect this receiver wants. `.kiwi` (upstream) takes the `ws/` marker the newer
+  /// mongoose API needs; `.web888` (Web-888 / RaspSDR, a fork from before that change) rejects it
+  /// outright — `bad URI_TS format`, socket closed with nothing sent. Anything else is treated as
+  /// upstream. See isKiwiProtocol() in src/services/sdrTypes.ts for the full account.
+  private let wsPrefix: String
+  /// "KiwiSDR" or "Web-888", for the refusal messages — they are the only explanation a stuck
+  /// user gets, so they must name the radio actually in front of them.
+  private let rxLabel: String
+
+  init(url: String, waterfall: WaterfallBuffer, variant: ServerType = .kiwi) {
     self.waterfall = waterfall
+    self.wsPrefix = (variant == .web888) ? "kiwi" : "ws/kiwi"
+    self.rxLabel  = (variant == .web888) ? "Web-888" : "KiwiSDR"
     // http(s)/ws(s)://host:port[/…] → ws(s)://host:port
     var u = url
     for p in ["https://", "http://", "wss://", "ws://"] { if u.hasPrefix(p) { u.removeFirst(p.count) } }
@@ -308,7 +319,7 @@ final class KiwiClient: ObservableObject, SDRClient {
     proc.autoContrast = 5
   }
 
-  private func wsURL(_ stream: String) -> URL { URL(string: "\(wsBase)/ws/kiwi/\(ts)/\(stream)")! }
+  private func wsURL(_ stream: String) -> URL { URL(string: "\(wsBase)/\(wsPrefix)/\(ts)/\(stream)")! }
 
   // ── Lifecycle ──
   func start() {
@@ -361,7 +372,7 @@ final class KiwiClient: ObservableObject, SDRClient {
         // ★ RELEASE: the raw socket state (`POSIXErrorCode(rawValue: 53)…`) is crumbed, not shown.
         Vitals.crumb("KIWI connect timeout — state: \(self.sockState)")
         self.fail(self.ownerBlockAdvice(self.sockState)
-                  ?? "No data from this KiwiSDR after 12s.")
+                  ?? "No data from this \(self.rxLabel) after 12s.")
       }
     }
     RunLoop.main.add(ct, forMode: .common); connectTimer = ct
@@ -387,7 +398,7 @@ final class KiwiClient: ObservableObject, SDRClient {
   private func ownerBlockAdvice(_ state: String) -> String? {
     let s = state.lowercased()
     guard s.contains("connection abort") || s.contains("rawvalue: 53") else { return nil }
-    return "This KiwiSDR closed the connection straight away.\n"
+    return "This \(rxLabel) closed the connection straight away.\n"
          + "Its owner has most likely restricted it to their own web page, which blocks apps like "
          + "Jr. Nothing you can change at this end — try another server."
   }
@@ -446,9 +457,9 @@ final class KiwiClient: ObservableObject, SDRClient {
       if shortSessions >= Self.shortSessionLimit {
         gaveUp = true
         sndSock.cancel(); wfSock.cancel()
-        fail("This KiwiSDR keeps ending the session after a few seconds — usually a listening-time "
+        fail("This \(rxLabel) keeps ending the session after a few seconds — usually a listening-time "
            + "limit, a full slot, or one-connection-per-listener. We\u{2019}ve stopped retrying so we "
-           + "don\u{2019}t hammer the owner\u{2019}s receiver. Try another KiwiSDR.")
+           + "don\u{2019}t hammer the owner\u{2019}s receiver. Try another receiver.")
         return
       }
     } else {
@@ -533,7 +544,7 @@ final class KiwiClient: ObservableObject, SDRClient {
             self.retrySnd(reason: st)
           } else {
             Vitals.crumb("KIWI socket failed — state: \(st)")
-            self.fail(self.ownerBlockAdvice(st) ?? "This KiwiSDR wouldn’t open a connection.")
+            self.fail(self.ownerBlockAdvice(st) ?? "This \(self.rxLabel) wouldn’t open a connection.")
           }
         }
       }
@@ -626,7 +637,7 @@ final class KiwiClient: ObservableObject, SDRClient {
     case "too_busy":
       // too_busy=0 is a NORMAL "you are not too busy" broadcast — only non-zero means full.
       if val != "0" && val != "" {
-        fail("This KiwiSDR is full — every listening slot is in use. Try another KiwiSDR, or use UberSDR or OpenWebRX.")
+        fail("This \(rxLabel) is full — every listening slot is in use. Try another receiver, or use UberSDR or OpenWebRX.")
       }
     case "ip_limit":
       // ★ THE DAILY PER-IP TIME LIMIT — the real reason behind "it lets us in and then kicks us".
@@ -634,14 +645,14 @@ final class KiwiClient: ObservableObject, SDRClient {
       // allowance for the day, the server still ACCEPTS the connection and then ends it seconds
       // later. Identical on the wire to a flaky link, which is why we used to blame Bluetooth and
       // reconnect forever. It is a rule, not a fault — say so and stop.
-      fail("You\u{2019}ve used this KiwiSDR\u{2019}s daily time allowance for your connection"
+      fail("You\u{2019}ve used this \(rxLabel)\u{2019}s daily time allowance for your connection"
          + " — the owner limits how long each listener gets per day. It\u{2019}ll let you back in"
-         + " tomorrow. Try another KiwiSDR in the meantime.", midSession: true)
+         + " tomorrow. Try another receiver in the meantime.", midSession: true)
     case "badp":
       // Non-zero = the sign-in was rejected: a private listen PASSWORD we don't have, or the owner
       // only allows their own web page. Owner setting, not an app fault.
       if val != "0" {
-        fail("This KiwiSDR is password-protected — the owner requires a listen password, which VibeSDR doesn’t have. Try another KiwiSDR, or use UberSDR or OpenWebRX.")
+        fail("This \(rxLabel) is password-protected — the owner requires a listen password, which VibeSDR doesn’t have. Try another receiver, or use UberSDR or OpenWebRX.")
       }
     default: break
     }

--- a/spike/WristSDR/WristSDR/SDRDirectory.swift
+++ b/spike/WristSDR/WristSDR/SDRDirectory.swift
@@ -11,13 +11,19 @@ import SwiftUI
 // ── Model ──────────────────────────────────────────────────────────────────────
 
 enum ServerType: String, Codable, CaseIterable {
-  case ubersdr, kiwi, owrx, fmdx, spyserver, rtltcp, vibeserver
+  // ★ web888 = a Web-888 / RaspSDR: KiwiSDR's protocol at a different WebSocket path, so it is
+  //   KiwiClient with one string changed. It MUST exist as its own case even though Jr shows no
+  //   picker for it: CloudSyncEngine maps an unknown serverType to `.ubersdr`, so a Web-888
+  //   favourite synced from the phone would arrive here as an UberSDR and fail on a protocol it
+  //   has never spoken. See isKiwiProtocol() in src/services/sdrTypes.ts.
+  case ubersdr, kiwi, web888, owrx, fmdx, spyserver, rtltcp, vibeserver
 
   /// Display name for the by-type sort + row badge.
   var display: String {
     switch self {
     case .ubersdr:   return "UberSDR"
     case .kiwi:      return "KiwiSDR"
+    case .web888:    return "Web-888"
     case .owrx:      return "OpenWebRX"
     case .fmdx:      return "FM-DX"
     case .spyserver: return "SpyServer"
@@ -28,12 +34,12 @@ enum ServerType: String, Codable, CaseIterable {
   /// Grouping order for the by-type sort (mirrors the phone's TYPE_ORDER).
   var order: Int {
     switch self {
-    case .ubersdr: return 0; case .kiwi: return 1; case .owrx: return 2
-    case .fmdx: return 3; case .vibeserver: return 4; case .spyserver: return 5; case .rtltcp: return 6
+    case .ubersdr: return 0; case .kiwi: return 1; case .web888: return 2; case .owrx: return 3
+    case .fmdx: return 4; case .vibeserver: return 5; case .spyserver: return 6; case .rtltcp: return 7
     }
   }
   /// Can the spike actually connect to this yet? (Others land as adapters arrive.)
-  var connectable: Bool { self == .ubersdr || self == .kiwi || self == .owrx || self == .fmdx || self == .vibeserver }
+  var connectable: Bool { self == .ubersdr || self == .kiwi || self == .web888 || self == .owrx || self == .fmdx || self == .vibeserver }
 }
 
 /// A server row — from a directory or a saved favourite. `url` is the connect key.
@@ -250,7 +256,9 @@ enum Directories {
         name: (r["name"] as? String) ?? "KiwiSDR",
         url: u,
         host: URL(string: u)?.host ?? u,
-        serverType: .kiwi,
+        // ★ The row names the firmware: `Web888_v2026.609` vs `KiwiSDR_v1.902`. They want
+        //   different WebSocket paths, so read it rather than assuming the parent product.
+        serverType: ((r["sw_version"] as? String) ?? "").lowercased().contains("888") ? .web888 : .kiwi,
         location: (r["loc"] as? String) ?? "",
         latitude: parseCoord(r["gps"], 0),
         longitude: parseCoord(r["gps"], 1),

--- a/spike/WristSDR/WristSDR/SpikeLink.swift
+++ b/spike/WristSDR/WristSDR/SpikeLink.swift
@@ -470,8 +470,9 @@ final class SpikeLink: ObservableObject {
 
     let c: any SDRClient
     switch type {
-    case .kiwi:
-      let k = KiwiClient(url: url, waterfall: waterfall)
+    case .kiwi, .web888:
+      // Same client; only the WebSocket path prefix differs (KiwiClient.wsURL).
+      let k = KiwiClient(url: url, waterfall: waterfall, variant: type)
       // Set BEFORE start(): the first wf_speed goes out during the handshake.
       k.onRelay = (transport == .iphone)
       c = k

--- a/src/components/AboutOverlay.tsx
+++ b/src/components/AboutOverlay.tsx
@@ -241,7 +241,7 @@ export default function AboutOverlay({ visible, onClose }: AboutOverlayProps) {
               {/* ★ Keep this in step with the backends we actually speak. It sat at three receivers and
                     "your own RTL-SDR" long after FM-DX, SpyServer, VibeServer, the Airspy HF+ and the
                     SDRplay RSP arrived — a one-line description of the app that had stopped describing it. */}
-              <Text style={styles.appSub}>A native mobile client for UberSDR, OpenWebRX, KiwiSDR, FM-DX and SpyServer receivers — and your own RTL-SDR, Airspy HF+ or SDRplay, shared by VibeServer</Text>
+              <Text style={styles.appSub}>A native mobile client for UberSDR, OpenWebRX, KiwiSDR, Web-888, FM-DX and SpyServer receivers — and your own RTL-SDR, Airspy HF+ or SDRplay, shared by VibeServer</Text>
             </View>
           </View>
 

--- a/src/components/AudioSheet.tsx
+++ b/src/components/AudioSheet.tsx
@@ -9,6 +9,7 @@ import type { DspFilterDesc, DspParamDesc } from './MenuSheet';
 import { NavCtx, NavRow, usePanelNav, useNavButton, useNavRange, NAV_FOCUS, noteTouchInteraction } from './PanelNav';
 import SectionIcon, { type SectionIconName } from './SectionIcon';
 import { meterText, useMeters, type MeterBus } from './ControlsBar';
+import { isKiwiProtocol } from '../services/sdrTypes';
 
 // Local copy of the menu's accessibility palette so this sheet is self-contained
 // (no shared-internals refactor of MenuSheet). Values mirror MenuSheet's `C`.
@@ -234,7 +235,7 @@ export interface AudioSheetProps {
    *  it to present the recording share sheet only once no RN modal is up (else
    *  the native share VC presents over this Modal and wedges touch handling). */
   onDismiss?: () => void;
-  serverType?: string;         // 'ubersdr' | 'owrx' | 'kiwi'
+  serverType?: string;         // 'ubersdr' | 'owrx' | 'kiwi' | 'web888'
   /** Meter display mode — squelch readouts follow it (S-units when 'smeter'), while the value SENT
    *  to the backend stays in its native unit. */
   signalMode?: 'snr' | 'smeter' | 'dbfs';
@@ -330,7 +331,7 @@ export default function AudioSheet({
   const { theme: t } = useTheme();
   const insets = useSafeAreaInsets();
   const isOwrx = serverType === 'owrx';
-  const isKiwi = serverType === 'kiwi';
+  const isKiwi = isKiwiProtocol(serverType);   // Web-888 has the same DSP surface
   const uberDsp = !recordingOnly && !isOwrx && !isLocal && !isKiwi;
 
   // Live signal reading — this sheet covers the signal bar, so show the CURRENT level next to the

--- a/src/components/MenuSheet.tsx
+++ b/src/components/MenuSheet.tsx
@@ -47,6 +47,7 @@ import { APP_VERSION } from '../constants/version';
 import UsbSdrIcon from './UsbSdrIcon';
 import VfoLockIcon from './VfoLockIcon';
 import SectionIcon, { type SectionIconName } from './SectionIcon';
+import { isKiwiProtocol, kiwiFamilyLabel } from '../services/sdrTypes';
 
 // ── Types ──────────────────────────────────────────────────────────────────────
 
@@ -199,7 +200,7 @@ export interface MenuSheetProps {
   onSelectDab?:     (id: number) => void;
   dabSpeed?:        number;            // DAB speed-correction factor (1 = off)
   onDabSpeed?:      (scale: number) => void;
-  serverType?:      string;   // 'ubersdr' | 'owrx' | 'kiwi' — picks the footer logo
+  serverType?:      string;   // 'ubersdr' | 'owrx' | 'kiwi' | 'web888' — picks the footer logo
   searchBookmarks?: ServerBookmark[];
   searchBands?:     ServerBand[];
   onSearchTune?:    (hz: number, mode?: string | null, isBand?: boolean) => void;
@@ -289,6 +290,10 @@ const SERVER_LOGOS: Record<string, any> = {
   ubersdr: require('../../assets/logo_ubersdr.png'),
   owrx:    require('../../assets/logo_owrx.png'),
   kiwi:    require('../../assets/logo_kiwi.png'),
+  // ★ No Web-888 asset ships, so it borrows the Kiwi mark — it runs Kiwi firmware, so this is
+  //   nearly right. The ?? fallback below is the UBERSDR logo, which would be plainly wrong:
+  //   an unmapped backend must never be branded as a different vendor's product.
+  web888:  require('../../assets/logo_kiwi.png'),
   // ★ VibeServer had no logo, so our OWN server fell back to a generic radio glyph
   //   in the very list where every other backend is branded (Stuart, 2026-07-29).
   vibeserver: require('../../assets/logo_vibeserver.png'),
@@ -738,7 +743,7 @@ export default function MenuSheet({
   const [profileOpen, setProfileOpen] = useState(false);   // OWRX profile dropdown
   const [dabOpen, setDabOpen] = useState(false);           // OWRX DAB programme dropdown
   const isOwrx = serverType === 'owrx';
-  const isKiwi = serverType === 'kiwi';
+  const isKiwi = isKiwiProtocol(serverType);   // Web-888 is a Kiwi for every purpose here
   // Local hardware: no server-side maps/admin/CW-skimmer/STT (those are network
   // server features). FT8/FT4 digital spots are decoded locally, so they stay.
   const isLocal = !!onLocalHardware;
@@ -1418,7 +1423,7 @@ export default function MenuSheet({
                 )}
                 <View>
                   <Text style={styles.footerServerName}>{isTcp ? 'RTL-TCP' : isLocal ? 'Local Hardware'
-                    : serverLabel ?? (serverType === 'kiwi' ? 'KiwiSDR' : isOwrx ? 'OpenWebRX' : 'UberSDR')}</Text>
+                    : serverLabel ?? (isKiwi ? kiwiFamilyLabel(serverType) : isOwrx ? 'OpenWebRX' : 'UberSDR')}</Text>
                   {isLocal ? (
                     <Text style={styles.footerServerVer}>via VibeDSP (native)</Text>
                   ) : serverVersion ? (

--- a/src/linking/DeepLinkHandler.ts
+++ b/src/linking/DeepLinkHandler.ts
@@ -14,10 +14,10 @@
 import { fetchInstances } from '../services/instancesApi';
 import type { SDRMode } from '../services/UberSDRClient';
 
-export type LinkBackend = 'ubersdr' | 'kiwi' | 'owrx' | 'rtltcp';
+export type LinkBackend = 'ubersdr' | 'kiwi' | 'web888' | 'owrx' | 'rtltcp';
 // Route serverType is a subset — rtltcp isn't a plain URL backend (needs the
 // on-device shim + host:port), so it's rejected in Phase 1.
-export type RouteServerType = 'ubersdr' | 'kiwi' | 'owrx';
+export type RouteServerType = 'ubersdr' | 'kiwi' | 'web888' | 'owrx';
 
 export interface DeepLinkRequest {
   uuid?:    string;
@@ -94,7 +94,8 @@ export function parseVibeSdrUrl(raw: string): DeepLinkRequest | null {
     // https/wss only — reject plaintext and anything exotic (brief §6).
     if (!/^(https|wss):\/\//i.test(u)) return null;
     const backend = (p.backend || '').toLowerCase();
-    if (backend !== 'ubersdr' && backend !== 'kiwi' && backend !== 'owrx' && backend !== 'rtltcp') return null;
+    if (backend !== 'ubersdr' && backend !== 'kiwi' && backend !== 'web888'
+        && backend !== 'owrx' && backend !== 'rtltcp') return null;
     req.url = u.replace(/\/+$/, '');
     req.backend = backend as LinkBackend;
   } else {

--- a/src/screens/InstancePickerScreen.tsx
+++ b/src/screens/InstancePickerScreen.tsx
@@ -37,7 +37,7 @@ import {
   MIN_RECOMMENDED_VERSION,
 } from '../services/instancesApi';
 import { checkConnection, detectServerType, probeServer, parseServerAddress, DEFAULT_PORT,
-         fetchOccupancy, type ServerOccupancy,
+         fetchOccupancy, type ServerOccupancy, isKiwiProtocol,
          type BackendType, type ServerType } from '../services/sdrTypes';
 import { vibeServerNeedsPin } from '../services/vibeAuth';
 
@@ -52,7 +52,8 @@ import { vibeServerNeedsPin } from '../services/vibeAuth';
 /** How each backend is named in the UI. 'auto' = let the probe decide. */
 const PROTO_LABEL: Record<BackendType, string> = {
   vibeserver: 'VibeServer', ubersdr: 'UberSDR', owrx: 'OpenWebRX',
-  kiwi: 'KiwiSDR', fmdx: 'FM-DX', rtltcp: 'rtl_tcp', spyserver: 'SpyServer',
+  kiwi: 'KiwiSDR', web888: 'Web-888', fmdx: 'FM-DX', rtltcp: 'rtl_tcp',
+  spyserver: 'SpyServer',
 };
 /** Offered in the add-server modal. AUTO first — it's right almost always; the
  *  explicit choices exist for raw-TCP servers on non-standard ports, which cannot
@@ -60,6 +61,12 @@ const PROTO_LABEL: Record<BackendType, string> = {
 const PROTO_CHOICES: Array<[BackendType | 'auto', string]> = [
   ['auto', 'Auto'], ['vibeserver', 'VibeServer'], ['rtltcp', 'rtl_tcp'],
   ['spyserver', 'SpyServer'], ['owrx', 'OpenWebRX'], ['kiwi', 'KiwiSDR'],
+  // ★ Web-888 sits NEXT TO KiwiSDR, and it has to be its own choice rather than a footnote to it:
+  // it is a Kiwi FORK whose WebSocket URL never gained the `ws/` prefix upstream added, so picking
+  // "KiwiSDR" for one is an instant, silent failure. Auto detects it from the page branding, and
+  // the adapter retries the other dialect by itself — but somebody who knows what they own should
+  // be able to just say so. (Also covers RaspSDR/RX-888 boxes, which are the same firmware.)
+  ['web888', 'Web-888'],
   ['ubersdr', 'UberSDR'], ['fmdx', 'FM-DX'],
 ];
 
@@ -116,6 +123,10 @@ const TYPE_LOGOS: Record<string, any> = {
   ubersdr: require('../../assets/logo_ubersdr.png'),
   owrx:    require('../../assets/logo_owrx.png'),
   kiwi:    require('../../assets/logo_kiwi.png'),
+  // ★ Web-888 borrows the Kiwi mark — no Web-888 asset ships, and it runs Kiwi firmware. Without
+  //   an entry a saved Web-888 favourite falls through to the 📻 glyph, alone in a list where
+  //   every other row is branded (the same complaint that added the VibeServer logo below).
+  web888:  require('../../assets/logo_kiwi.png'),
   // ★ VibeServer had no logo, so our OWN server fell back to a generic radio glyph
   //   in the very list where every other backend is branded (Stuart, 2026-07-29).
   vibeserver: require('../../assets/logo_vibeserver.png'),
@@ -186,10 +197,12 @@ function favSnr(f: Favourite, meta: FavMeta): number | null {
   return meta[normUrl(f.url)]?.snr ?? f.bestSnr ?? null;
 }
 // Grouping order + display names for the by-type sort.
-const TYPE_ORDER: Record<string, number> = { ubersdr: 0, kiwi: 1, owrx: 2, fmdx: 3, vibeserver: 4, spyserver: 5, rtltcp: 6 };
+// ★ web888 sits immediately after kiwi so the two Kiwi-protocol groups are adjacent under the
+//   by-type sort, rather than a lone 'Web-888' group stranded after RTL-TCP.
+const TYPE_ORDER: Record<string, number> = { ubersdr: 0, kiwi: 1, web888: 2, owrx: 3, fmdx: 4, vibeserver: 5, spyserver: 6, rtltcp: 7 };
 const TYPE_NAME: Record<string, string> = {
-  ubersdr: 'UberSDR', kiwi: 'KiwiSDR', owrx: 'OpenWebRX', fmdx: 'FM-DX', vibeserver: 'VibeServer',
-  spyserver: 'SpyServer', rtltcp: 'RTL-TCP',
+  ubersdr: 'UberSDR', kiwi: 'KiwiSDR', web888: 'Web-888', owrx: 'OpenWebRX', fmdx: 'FM-DX',
+  vibeserver: 'VibeServer', spyserver: 'SpyServer', rtltcp: 'RTL-TCP',
 };
 const favType = (f: Favourite) => (f.serverType ?? 'ubersdr') as string;
 function sortFavs(list: Favourite[], mode: FavSort, loc: { lat: number; lon: number } | null, meta: FavMeta): Favourite[] {
@@ -292,7 +305,7 @@ export default function InstancePickerScreen({ navigation, route }: Props) {
   // KiwiSDR name/callsign identity. `identModal` open = the entry box is up; its optional
   // `connect` holds a pending connection to resume after saving (from a connect), or is absent
   // (editing via the prefill box). `kiwiIdentValue` is the saved value shown in the box.
-  const [identModal,  setIdentModal]    = useState<null | { connect?: { url: string; name: string; password?: string; lon?: number | null; type?: 'ubersdr' | 'kiwi' | 'owrx' | 'fmdx' } }>(null);
+  const [identModal,  setIdentModal]    = useState<null | { connect?: { url: string; name: string; password?: string; lon?: number | null; type?: 'ubersdr' | 'kiwi' | 'web888' | 'owrx' | 'fmdx' } }>(null);
   const [identPrefill, setIdentPrefill] = useState('');
   const [kiwiIdentValue, setKiwiIdentValue] = useState('');
   useEffect(() => { getKiwiIdent().then(setKiwiIdentValue).catch(() => {}); }, []);
@@ -322,7 +335,7 @@ export default function InstancePickerScreen({ navigation, route }: Props) {
     { id: 'welcome', title: 'Welcome to VibeSDR',
       body: 'Browse public SDR servers below, or set a favourite as your default to skip straight in next time.' },
     { id: 'custom', title: 'Your own server',
-      body: 'Got a private UberSDR, OpenWebRX or KiwiSDR? Enter its address here to connect to it directly.',
+      body: 'Got a private UberSDR, OpenWebRX, KiwiSDR or Web-888? Enter its address here to connect to it directly.',
       target: tourRef('customUrl') },
   ], { storageKey: 'lsv_tour_picker_v1' });
   useEffect(() => {
@@ -559,7 +572,7 @@ export default function InstancePickerScreen({ navigation, route }: Props) {
     })();
   }, [mergeMeta]);
 
-  const connect = useCallback(async (url: string, name: string, password?: string, serverLongitude?: number | null, serverType?: 'ubersdr' | 'kiwi' | 'owrx' | 'fmdx') => {
+  const connect = useCallback(async (url: string, name: string, password?: string, serverLongitude?: number | null, serverType?: 'ubersdr' | 'kiwi' | 'web888' | 'owrx' | 'fmdx') => {
     if (!url) return;
     const cleaned = url.trim().replace(/\/$/, '');
     // Most-Used tally: connecting to a favourite (server or custom URL) bumps its visit count so
@@ -574,7 +587,8 @@ export default function InstancePickerScreen({ navigation, route }: Props) {
     // KiwiSDR: capture a name/callsign once (saved like the VibeServer PIN). Many Kiwis refuse
     // anonymous or require an ident — so ensure one exists before connecting. Prompt only when
     // it's empty; thereafter the adapter loads and sends it silently.
-    if (serverType === 'kiwi') {
+    // ★ Web-888 too — same server code, same `SET ident_user`, same owner restrictions.
+    if (isKiwiProtocol(serverType)) {
       const id = await getKiwiIdent();
       if (!id) {
         setIdentPrefill('');
@@ -887,16 +901,25 @@ export default function InstancePickerScreen({ navigation, route }: Props) {
       proto = 'spyserver';
       if (tcpProto !== 'spyserver') setTcpProto('spyserver');   // flip the toggle for feedback
     }
-    // The port field is a fallback — a port typed into the HOST field wins, since
-    // that's the natural way to paste "host:8073".
-    let p = parseInt(tcpPort.trim(), 10);
+    // ★★★ THE PORT FIELD HAS TO REACH THE URL, NOT JUST THE PORT NUMBER. This used to parse the
+    // host WITHOUT the typed port, then patch `port` afterwards and return `u.url` untouched — so
+    // "web-888.local" + "8073" produced port 8073 and the url `http://web-888.local`, which is
+    // port 80. Detection still found the receiver (probeServer also tries host:port directly) and
+    // saved a correctly-typed favourite, but the connect used the portless url and was REFUSED.
+    // Reported 2026-08-03; it affected every backend, not just Web-888, and the saved favourite
+    // working on the second tap is what disguised it.
+    //
+    // ★ Feed the port in as the parser's default instead. parseServerAddress already prefers a
+    //   port written into the host text over the default, so "a port typed into the HOST field
+    //   wins" still holds — and now `port` and `url` cannot disagree, because both come out of the
+    //   same parse. Do not reintroduce a separate `p`.
+    const typed = parseInt(tcpPort.trim(), 10);
+    const portField = Number.isFinite(typed) && typed > 0 && typed < 65536 ? typed : undefined;
     // ★ Same parser as the paste box: a named server may equally live behind TLS or in a
     // subfolder, and the two entry points must not disagree about what an address IS.
-    const u = parseServerAddress(h, proto === 'auto' ? undefined : DEFAULT_PORT[proto]);
+    const u = parseServerAddress(h, portField ?? (proto === 'auto' ? undefined : DEFAULT_PORT[proto]));
     if (!u) return null;
-    h = u.host;
-    if (/:\d+$/.test(tcpHost.trim()) || !Number.isFinite(p) || p <= 0 || p > 65535) p = u.port;
-    return { host: h, port: p, proto, url: u.url };
+    return { host: u.host, port: u.port, proto, url: u.url };
   }, [tcpHost, tcpPort, tcpProto]);
 
   const tcpModalConnect = useCallback(async (save: boolean) => {
@@ -907,15 +930,18 @@ export default function InstancePickerScreen({ navigation, route }: Props) {
     // On AUTO, probe before saving — so the favourite remembers what it actually is
     // and reconnects straight to the right backend next time, with no second probe.
     let type: BackendType | null = parsed.proto === 'auto' ? null : parsed.proto;
+    // ★ Connect to the address that ANSWERED, not the one typed — see ProbeResult.url.
+    let url = parsed.url;
     if (!type) {
       setConnecting(true);
-      type = await probeServer(parsed.host, parsed.port, null, parsed.url);
+      const probed = await probeServer(parsed.host, parsed.port, null, parsed.url);
       setConnecting(false);
-      if (!type) {
+      if (!probed) {
         Alert.alert('Custom server',
           `Nothing answered at ${parsed.host}:${parsed.port}.\n\nIf it's an rtl_tcp or SpyServer on a non-standard port, pick the type instead of Auto — raw TCP can't be detected.`);
         return;
       }
+      type = probed.type; url = probed.url;
     }
     if (save) {
       const next = [...tcpFavs.filter(f => !(f.host === parsed.host && f.port === parsed.port)),
@@ -923,7 +949,7 @@ export default function InstancePickerScreen({ navigation, route }: Props) {
       setTcpFavs(next); saveTcpFavs(next).catch(() => {});
     }
     setTcpModal(false); setTcpName(''); setTcpHost(''); setTcpPort('');
-    connectDetected(type, parsed.host, parsed.port, name, parsed.url);
+    connectDetected(type, parsed.host, parsed.port, name, url);
   }, [parseTcpEntry, tcpName, tcpFavs, connectDetected]);
 
   const removeTcpFav = useCallback((fav: TcpFav) => {
@@ -1038,9 +1064,9 @@ export default function InstancePickerScreen({ navigation, route }: Props) {
     // (NSAllowsArbitraryLoads) — most Kiwi/OpenWebRX receivers are hobbyist HTTP
     // boxes with no TLS, so we don't block them.
     setConnecting(true);
-    const type = await probeServer(u.host, u.port, null, u.url);
+    const probed = await probeServer(u.host, u.port, null, u.url);
     setConnecting(false);
-    if (!type) {
+    if (!probed) {
       // Typed a bare host with no port? DEFAULT_PORT guessed 80/8073, which is
       // never where a VibeServer lives. Sweep its range before giving up, so
       // "just type the IP" works however the server numbered itself today.
@@ -1054,7 +1080,7 @@ export default function InstancePickerScreen({ navigation, route }: Props) {
         `Nothing answered at ${u.host}:${u.port}.\n\nIf this is an rtl_tcp or SpyServer on a non-standard port, add it with the + button and pick the type — raw TCP servers can't be auto-detected.`);
       return;
     }
-    connectDetected(type, u.host, u.port, raw, u.url);
+    connectDetected(probed.type, u.host, u.port, raw, probed.url);
   }, [customUrl, connectSpy, connectDetected]);
 
   const handleSetDefault = useCallback((inst: DefaultInstance) => {
@@ -1857,11 +1883,16 @@ export default function InstancePickerScreen({ navigation, route }: Props) {
         const urlFocused = chooserSlot(() => customInputRef.current?.focus());
         return (
         <View ref={tourRef('customUrl')} collapsable={false} style={styles.customRow}>
+          {/* ★ THE EXAMPLE MUST SHOW A PORT. Without one it reads as "hostname only", and a bare
+              hostname resolves to port 80 — where essentially no receiver listens. KiwiSDR,
+              Web-888, OpenWebRX and UberSDR all default to 8073. Reported 2026-08-03: this box
+              gave no clue what belonged in it, so the + modal got used instead — and that path
+              then hit the port-dropped-from-the-URL bug in parseTcpEntry. */}
           <TextInput
             ref={customInputRef}
             style={[styles.urlInput, { fontFamily: F, fontSize: fs(12), color: C.amber, borderColor: urlFocused ? NAV_FOCUS : C.border },
                     urlFocused && { borderWidth: 2 }]}
-            placeholder="Custom URL  e.g. sdr.example.com"
+            placeholder="Custom URL  e.g. sdr.example.com:8073"
             placeholderTextColor={C.textDim}
             value={customUrl}
             onChangeText={setCustomUrl}

--- a/src/screens/SDRScreen.tsx
+++ b/src/screens/SDRScreen.tsx
@@ -79,7 +79,8 @@ import { DecoderClient, RTTY_PRESETS,
          type SpotRow, type SpotsKind,
          type ChatUserRow }                            from '../services/DecoderClient';
 import { type DecoderImageHandle }                     from '../components/DecoderImageCanvas';
-import { MIN_HZ, MAX_HZ, STEPS, stepsForFreq, fetchOccupancy } from '../services/sdrTypes';
+import { MIN_HZ, MAX_HZ, STEPS, stepsForFreq, fetchOccupancy,
+         isKiwiProtocol, kiwiFamilyLabel } from '../services/sdrTypes';
 import { v4 as uuidv4 }                                from 'uuid';
 import AsyncStorage                                    from '@react-native-async-storage/async-storage';
 import { setDefaultInstance, getDefaultInstance,
@@ -1505,7 +1506,12 @@ export default function SDRScreen({ route, navigation }: Props) {
     raw.replace(/[^A-Za-z0-9\-_\/]/g, '').replace(/^[-_\/]+|[-_\/]+$/g, '').slice(0, 15), []);
 
   const isOwrx = route.params.serverType === 'owrx';
-  const isKiwi = route.params.serverType === 'kiwi';
+  // Web-888 included: same server, same DSP descriptors, same everything but the URL.
+  const isKiwi = isKiwiProtocol(route.params.serverType);
+  // What to CALL this receiver in every card below. Hard-coded "KiwiSDR" in five places was
+  // wrong the moment Web-888 became its own server type — and these cards are the only
+  // explanation a stuck user gets, so naming the wrong radio sends them hunting the wrong fault.
+  const rxLabel = kiwiFamilyLabel(route.params.serverType);
   // Kiwi exposes its noise filters/blanker as DSP descriptors → reuse the
   // UberSDR server-DSP menu UI (filter selector + param sliders).
   useEffect(() => {
@@ -2759,7 +2765,7 @@ export default function SDRScreen({ route, navigation }: Props) {
         // Back to Instances / Try Again / Compatibility Mode. Owner restrictions (app-block,
         // private password, slot limits) can't be fixed by the UberSDR bypass-password box, so
         // it's never offered here — that route is UberSDR-only, for per-IP RATE limits.
-        if (route.params.serverType === 'kiwi') { kiwiRefusedRef.current = true; setKiwiRefused(msg); return; }
+        if (isKiwiProtocol(route.params.serverType)) { kiwiRefusedRef.current = true; setKiwiRefused(msg); return; }
         if (/429|rate.?limit|too many|refused|denied|blocked|busy/i.test(msg)) {
           setPwPrompt(true);
         } else {
@@ -5487,15 +5493,15 @@ export default function SDRScreen({ route, navigation }: Props) {
       {/* OWRX server crashed/restarted (common on OWRX). Keep the app alive and
           tell the user to wait before reconnecting (the server's still booting). */}
       {!kiwiRefused && serverLost && (() => {
-        const lostLabel = route.params.serverType === 'kiwi' ? 'KiwiSDR'
+        const lostLabel = isKiwiProtocol(route.params.serverType) ? kiwiFamilyLabel(route.params.serverType)
                         : route.params.serverType === 'owrx' ? 'OpenWebRX'
                         : 'SDR';
         return (
         <View style={styles.serverLostWrap} pointerEvents="box-none">
           <View style={styles.serverLostCard}>
             <Text style={styles.serverLostTitle}>{lostLabel} server stopped responding</Text>
-            <Text style={styles.serverLostBody}>{route.params.serverType === 'kiwi'
-              ? "The receiver dropped the connection. KiwiSDR owners with few slots often restrict access: some allow only their own web page, so apps like VibeSDR are refused the moment they connect; some block broadcast / commercial bands and disconnect you when you tune there. If reconnecting drops the same way it's likely an owner restriction — try another receiver. Otherwise it may just be busy or restarting: wait a minute and reconnect."
+            <Text style={styles.serverLostBody}>{isKiwiProtocol(route.params.serverType)
+              ? `The receiver dropped the connection. ${lostLabel} owners with few slots often restrict access: some allow only their own web page, so apps like VibeSDR are refused the moment they connect; some block broadcast / commercial bands and disconnect you when you tune there. If reconnecting drops the same way it's likely an owner restriction — try another receiver. Otherwise it may just be busy or restarting: wait a minute and reconnect.`
               : `The receiver dropped the connection — ${lostLabel} servers restart from time to time. Please wait a minute, then reconnect — or pick another from the list.`}</Text>
             <View style={styles.serverLostBtnRow}>
               <TouchableOpacity style={[styles.serverLostBtn, styles.serverLostBtnAlt]}
@@ -5509,7 +5515,7 @@ export default function SDRScreen({ route, navigation }: Props) {
             </View>
             {/* A Kiwi that keeps kicking a connected user still lets them reach compatibility mode —
                 otherwise unreachable, since the initial-refusal card never shows once it connects. */}
-            {route.params.serverType === 'kiwi' && (
+            {isKiwiProtocol(route.params.serverType) && (
               <TouchableOpacity style={[styles.serverLostBtn, { alignSelf: 'stretch', marginTop: 8 }]}
                 onPress={() => { setServerLost(false); setCompatWarn(true); }} activeOpacity={0.85}>
                 <Text style={styles.serverLostBtnText}>OPEN IN COMPATIBILITY MODE</Text>
@@ -5543,7 +5549,7 @@ export default function SDRScreen({ route, navigation }: Props) {
         <View style={styles.serverLostWrap} pointerEvents="box-none">
           <View style={styles.serverLostCard}>
             <Text style={styles.serverLostTitle}>Receiver unavailable</Text>
-            <Text style={styles.serverLostBody}>This KiwiSDR has no free channel for you right now — it may be full, or its channels may be password-protected or limited to local users (the directory's user count can be out of date). Pick another receiver, or try again shortly.</Text>
+            <Text style={styles.serverLostBody}>This {rxLabel} has no free channel for you right now — it may be full, or its channels may be password-protected or limited to local users (the directory's user count can be out of date). Pick another receiver, or try again shortly.</Text>
             <View style={styles.serverLostBtnRow}>
               <TouchableOpacity style={[styles.serverLostBtn, styles.serverLostBtnAlt]}
                 onPress={() => navigation.goBack()} activeOpacity={0.85}>
@@ -5591,7 +5597,7 @@ export default function SDRScreen({ route, navigation }: Props) {
         <View style={styles.serverLostWrap} pointerEvents="box-none">
           <View style={styles.serverLostCard}>
             <Text style={styles.serverLostTitle}>Open in compatibility mode?</Text>
-            <Text style={styles.serverLostBody}>This opens the KiwiSDR’s OWN web interface inside VibeSDR — you’ll use Kiwi’s native controls and layout, not VibeSDR’s. The advanced VibeSDR features won’t apply here: no background audio, no recording, no lock-screen or Apple Watch playback, and none of VibeSDR’s waterfall or audio controls. Tap “← VibeSDR” at the top to come back.</Text>
+            <Text style={styles.serverLostBody}>This opens the {rxLabel}’s OWN web interface inside VibeSDR — you’ll use the receiver’s native controls and layout, not VibeSDR’s. The advanced VibeSDR features won’t apply here: no background audio, no recording, no lock-screen or Apple Watch playback, and none of VibeSDR’s waterfall or audio controls. Tap “← VibeSDR” at the top to come back.</Text>
             <View style={{ gap: 8, marginTop: 4, alignSelf: 'stretch' }}>
               <TouchableOpacity style={[styles.serverLostBtn, styles.serverLostBtnAlt, { alignSelf: 'stretch' }]}
                 onPress={() => { setCompatWarn(false); navigation.goBack(); }} activeOpacity={0.85}>
@@ -5643,7 +5649,7 @@ export default function SDRScreen({ route, navigation }: Props) {
       {compatUrl && (
         <BrowserOverlay
           url={compatUrl}
-          title={(instanceName ?? 'KiwiSDR') + ' — web'}
+          title={(instanceName ?? rxLabel) + ' — web'}
           backLabel="← VibeSDR"
           onClose={() => { setCompatUrl(null); navigation.goBack(); }}
         />
@@ -5721,7 +5727,7 @@ export default function SDRScreen({ route, navigation }: Props) {
               No response from {instanceName || 'the receiver'}. {route.params.isLocal
                 ? 'Check the SDR is plugged in and try again, or pick another server.'
                 : isKiwi
-                  ? "It may be offline or a temporary network issue — but if a retry also fails, this KiwiSDR's owner likely only allows their own web page and blocks apps like VibeSDR. Try another, or use UberSDR / OpenWebRX."
+                  ? `It may be offline or a temporary network issue — but if a retry also fails, this ${rxLabel}'s owner likely only allows their own web page and blocks apps like VibeSDR. Try another, or use UberSDR / OpenWebRX.`
                   : 'It may be offline or unreachable — try again or pick another server.'}
             </Text>
             <View style={styles.serverLostBtnRow}>

--- a/src/services/KiwiAdapter.ts
+++ b/src/services/KiwiAdapter.ts
@@ -108,8 +108,9 @@ const KIWI_CAPS: Omit<BackendCapabilities, 'freqRange'> = {
 
 export class KiwiAdapter implements SDRBackend {
   /** A getter, not a field: the variant can flip mid-handshake (tryOtherWsPrefix), and after it
-   *  does, `kind` must report what we are actually talking to. */
-  get kind(): BackendKind { return this.variant; }
+   *  does, `kind` must report what we are actually talking to — but only once a receiver has
+   *  CONFIRMED it by answering. An unconfirmed swap is a guess; see label(). */
+  get kind(): BackendKind { return this.variantConfirmed ? this.variant : this.askedVariant; }
   readonly caps: BackendCapabilities = { ...KIWI_CAPS, freqRange: [0, KIWI_FULL_BW] };
   readonly uuid: string;
 
@@ -121,13 +122,40 @@ export class KiwiAdapter implements SDRBackend {
   /** Kiwi dialect — from the caller's server type, then self-corrected once if we guessed wrong. */
   private variant: KiwiVariant;
   private get wsPrefix(): string { return KIWI_WS_PREFIX[this.variant]; }
+  /** What the CALLER said this receiver is, never overwritten. The dialect probe is a guess until
+   *  something answers, and an unanswered guess must not be reported to the user as fact — see
+   *  label(). */
+  private readonly askedVariant: KiwiVariant;
   /** The URL-dialect probe fires at most once per adapter. See tryOtherWsPrefix(). */
   private prefixSwapped = false;
-  /** Has the server said ANYTHING on this socket? The one signal that separates a wrong URL
-   *  (closed with zero bytes) from a receiver that answered and then refused us. */
+  /** Has the server said ANYTHING on this attempt? The one signal that separates a wrong URL
+   *  (closed with zero bytes) from a receiver that answered and then refused us. Reset per
+   *  attempt, because it gates the swap — use variantConfirmed for anything durable. */
   private sawServerMsg = false;
-  /** How to name this receiver to the user — "KiwiSDR" or "Web-888". */
-  private label(): string { return this.variant === 'web888' ? 'Web-888' : 'KiwiSDR'; }
+  /** ★★★ HAS A RECEIVER ACTUALLY ANSWERED ON THE CURRENT PREFIX? Only that is evidence of which
+   *  dialect it really speaks. Unlike sawServerMsg this is never reset: a reconnect does not
+   *  un-learn what the receiver already told us. */
+  private variantConfirmed = false;
+
+  /** How to name this receiver to the user — "KiwiSDR" or "Web-888".
+   *
+   *  ★★★ A FAILED PROBE MUST NOT RENAME SOMEONE'S RADIO. This used to read `this.variant`, which
+   *  the retry mutates. A receiver that refuses us with ZERO bytes is indistinguishable from a
+   *  wrong URL, so the swap fires, the second attempt fails too, and every message then described
+   *  a KiwiSDR — picked from the KiwiSDR directory — as "This Web-888…". Reported 2026-08-03
+   *  against a Kiwi that blocks app clients (it fails on the shipped build too, so the refusal is
+   *  real; only the NAME was ours).
+   *
+   *  ★ That is the same class of fault as the bug this whole change exists to fix: the app stating
+   *    something false about the user's own hardware. It is worse than saying nothing, because it
+   *    sends someone looking for a Web-888 problem they do not have.
+   *
+   *  ★★ So: report the confirmed dialect if a receiver has spoken to us, otherwise report what the
+   *     caller asked for. Never the untested half of a swap. */
+  private label(): string {
+    const v = this.variantConfirmed ? this.variant : this.askedVariant;
+    return v === 'web888' ? 'Web-888' : 'KiwiSDR';
+  }
 
   private sndWs: WebSocket | null = null;
   private wfWs: WebSocket | null = null;
@@ -190,6 +218,7 @@ export class KiwiAdapter implements SDRBackend {
     this.cb = callbacks;
     this.password = password ?? '';
     this.variant = variant;
+    this.askedVariant = variant;
     this.wsBase = KiwiAdapter.toWsBase(baseUrl);
     getKiwiIdent().then((v) => { const s = sanitizeIdent(v); if (s) this.ident = s; }).catch(() => {});
   }
@@ -432,7 +461,10 @@ export class KiwiAdapter implements SDRBackend {
     const was = this.wsPrefix;
     this.prefixSwapped = true;
     this.variant = this.variant === 'web888' ? 'kiwi' : 'web888';
-    this.dbg(`closed with no reply on /${was}/ — retrying as ${this.label()} (/${this.wsPrefix}/)`);
+    // ★ Name the PREFIX, not a product. label() deliberately refuses to report an unconfirmed
+    //   swap, so calling it here printed "retrying as KiwiSDR (/kiwi/)" — the old name against the
+    //   new path. The prefix is the only fact at this point.
+    this.dbg(`closed with no reply on /${was}/ — retrying at /${this.wsPrefix}/`);
     this.stopKeepalive();
     this.closeSocket('sndWs');
     this.closeSocket('wfWs');
@@ -499,6 +531,7 @@ export class KiwiAdapter implements SDRBackend {
     // The server has spoken → the URL dialect was right, so stop second-guessing it. From here a
     // close is a real event and must be reported as one, never retried at a different URL.
     this.sawServerMsg = true;
+    this.variantConfirmed = true;      // it answered on this prefix — the dialect is now a fact
     if (buf.length < 3) return;
     const tag = String.fromCharCode(buf[0], buf[1], buf[2]);
     if (tag === 'MSG') {
@@ -515,7 +548,7 @@ export class KiwiAdapter implements SDRBackend {
 
   // ── text (MSG) ───────────────────────────────────────────────────────────
   private onText(data: string, stream: 'SND' | 'W/F'): void {
-    this.sawServerMsg = true;                      // see onBinaryFrame
+    this.sawServerMsg = true; this.variantConfirmed = true;   // see onBinaryFrame
     this.dbg(stream + ' rx: ' + data.slice(0, 120));
     if (!data.startsWith('MSG')) return;            // CLI / other — ignore
     const body = data.slice(4);                     // skip "MSG "

--- a/src/services/KiwiAdapter.ts
+++ b/src/services/KiwiAdapter.ts
@@ -1,5 +1,7 @@
 // KiwiAdapter — native KiwiSDR backend (v3b3). Two WebSockets to
-// ws(s)://host:port/ws/kiwi/<ts>/{SND,W/F}. Mirrors the shipped OWRX approach:
+// ws(s)://host:port/<prefix>/<ts>/{SND,W/F}, where <prefix> is `ws/kiwi` on a real KiwiSDR and
+// `kiwi` on a Web-888 / RaspSDR — see KIWI_WS_PREFIX and isKiwiProtocol() in sdrTypes for why
+// the same protocol lives at two URLs. Mirrors the shipped OWRX approach:
 // everything (control, waterfall, audio decode) lives in TS, and decoded PCM is
 // pushed to the native player via pushExternalPcm so background audio works the
 // same as OWRX. No native Kiwi engine, no Kiwi server-side extensions (deferred —
@@ -84,6 +86,16 @@ const KIWI_MODE: Record<SDRMode, { mod: string; lo: number; hi: number }> = {
   wfm: { mod: 'nbfm', lo: -6000, hi:  6000 }, // unused (Kiwi has no WFM) — local-only mode
 };
 
+/** Which dialect of the Kiwi URL a receiver wants. Same wire protocol either way — the ONLY
+ *  difference is this string, and getting it wrong means the server closes the socket without
+ *  sending a byte. `no_wf` (waterfall-less) exists on both and is deliberately not offered:
+ *  the app always wants a waterfall. */
+export type KiwiVariant = 'kiwi' | 'web888';
+export const KIWI_WS_PREFIX: Record<KiwiVariant, string> = {
+  kiwi:   'ws/kiwi',   // upstream KiwiSDR (jks-prv), mongoose-7 API — needs the `ws/` marker
+  web888: 'kiwi',      // Web-888 / RaspSDR fork — predates it, rejects `ws/` outright
+};
+
 const KIWI_CAPS: Omit<BackendCapabilities, 'freqRange'> = {
   profiles: false,
   serverSideZoom: true,
@@ -95,7 +107,9 @@ const KIWI_CAPS: Omit<BackendCapabilities, 'freqRange'> = {
 };
 
 export class KiwiAdapter implements SDRBackend {
-  readonly kind: BackendKind = 'kiwi';
+  /** A getter, not a field: the variant can flip mid-handshake (tryOtherWsPrefix), and after it
+   *  does, `kind` must report what we are actually talking to. */
+  get kind(): BackendKind { return this.variant; }
   readonly caps: BackendCapabilities = { ...KIWI_CAPS, freqRange: [0, KIWI_FULL_BW] };
   readonly uuid: string;
 
@@ -103,6 +117,17 @@ export class KiwiAdapter implements SDRBackend {
   private wsBase: string;
   private password: string;
   private ts = Date.now();
+
+  /** Kiwi dialect — from the caller's server type, then self-corrected once if we guessed wrong. */
+  private variant: KiwiVariant;
+  private get wsPrefix(): string { return KIWI_WS_PREFIX[this.variant]; }
+  /** The URL-dialect probe fires at most once per adapter. See tryOtherWsPrefix(). */
+  private prefixSwapped = false;
+  /** Has the server said ANYTHING on this socket? The one signal that separates a wrong URL
+   *  (closed with zero bytes) from a receiver that answered and then refused us. */
+  private sawServerMsg = false;
+  /** How to name this receiver to the user — "KiwiSDR" or "Web-888". */
+  private label(): string { return this.variant === 'web888' ? 'Web-888' : 'KiwiSDR'; }
 
   private sndWs: WebSocket | null = null;
   private wfWs: WebSocket | null = null;
@@ -159,10 +184,12 @@ export class KiwiAdapter implements SDRBackend {
    *  round-trip later), so it's always ready in time. */
   private ident = 'VibeSDR';
 
-  constructor(baseUrl: string, uuid: string, callbacks: BackendCallbacks, password?: string) {
+  constructor(baseUrl: string, uuid: string, callbacks: BackendCallbacks, password?: string,
+              variant: KiwiVariant = 'kiwi') {
     this.uuid = uuid;
     this.cb = callbacks;
     this.password = password ?? '';
+    this.variant = variant;
     this.wsBase = KiwiAdapter.toWsBase(baseUrl);
     getKiwiIdent().then((v) => { const s = sanitizeIdent(v); if (s) this.ident = s; }).catch(() => {});
   }
@@ -193,7 +220,7 @@ export class KiwiAdapter implements SDRBackend {
   }
 
   private url(stream: 'SND' | 'W/F'): string {
-    return `${this.wsBase}/ws/kiwi/${this.ts}/${stream}`;
+    return `${this.wsBase}/${this.wsPrefix}/${this.ts}/${stream}`;
   }
 
   /** Receiver location from the Kiwi /status text endpoint (`gps=(lat, lon)`)
@@ -246,88 +273,173 @@ export class KiwiAdapter implements SDRBackend {
     this.gapHist = []; this.lastFrameAt = 0; this.lastLink = -1;
     this.verMaj = null; this.verMin = null; this.serverInfoSent = false;
     this.everConnected = false; this.errorShown = false;
+    this.prefixSwapped = false;
 
     return new Promise<void>((resolve, reject) => {
       let settled = false;
-      const done = () => { if (!settled) { settled = true; resolve(); } };
-      const fail = (e: any) => { if (!settled) { settled = true; reject(e); } };
-
-      // Open the SND socket FIRST. The reference client only opens W/F *after*
-      // the SND auth succeeds (kiwi.js: "repeat the auth for the second
-      // websocket … we only get here if the first auth has worked"). Opening
-      // both at once makes the Kiwi drop the SND connection after a few seconds.
-      try {
-        this.sndWs = new (WebSocket as any)(this.url('SND'), null, { headers: { 'User-Agent': KIWI_UA } }) as WebSocket;
-      } catch (e) { fail(e); return; }
-      this.sndWs.binaryType = 'arraybuffer';
-
-      this.sndWs.onopen = () => {
-        this.dbg('SND open');
-        // ★★ '#' MEANS "NO PASSWORD", NOT AN EMPTY STRING. Kiwi's own client:
-        //      pwd = (pwd != '') ? pwd : '#';
-        //      ext_send('SET auth t=' + conn_type + ' p=' + pwd + ipl + reset_s, ws);
-        // We sent `p=` with nothing after it. Verified 2026-07-31 that this alone does NOT fix the
-        // receivers that refuse us after ~10 s — so it is not the cause of that — but behaving
-        // identically to the reference client on someone else's hardware is the whole point of
-        // memory/third_party_receiver_etiquette.md, and an empty field is the sort of thing a
-        // stricter server is entitled to reject.
-        this.sndSend(`SET auth t=kiwi p=${this.password || '#'}`);
-        // Ident goes EARLY, right after auth — a "require name/callsign" server checks it at
-        // connect time, so sending it late (buried in the RX params) means the refusal has
-        // already happened. See kiwiIdent / IdentModal.
-        this.sndSend(`SET ident_user=${this.ident}`);
-        this.sndSend('SERVER DE CLIENT openwebrx.js SND');
-        // RX params (which START the audio stream) — a short tick lets the
-        // server process auth first; also re-asserted on the audio_rate MSG.
-        setTimeout(() => { if (this.started) this.sendRxParams(); }, 150);
-      };
-      this.sndWs.onmessage = (e) => {
-        try {
-          if (typeof e.data === 'string') this.onText(e.data, 'SND');
-          else {
-            const u8 = new Uint8Array(e.data as ArrayBuffer);
-            this.rxBytes += u8.length;
-            this.startRateMeter();
-            this.onBinaryFrame(u8, 'SND');
-          }
-          this.openWf();
-        } catch (err: any) { this.dbg('SND msg err: ' + (err?.message ?? err)); }
-      };
-      this.sndWs.onerror = () => { this.dbg('SND error'); fail(new Error('KiwiSDR SND socket error')); };
-      this.sndWs.onclose = (ev: any) => { this.dbg('SND close code=' + ev?.code + ' reason=' + ev?.reason); this.onSocketDrop(ev?.reason ?? ''); fail(new Error('KiwiSDR SND closed')); };
-
-      // Open W/F right away too (both share this.ts). The first-SND-MSG gate
-      // (openWf in onmessage) is kept as a no-op fallback via the wfOpened guard.
-      this.openWf();
-
-      // Keepalive on BOTH sockets — Kiwi kicks a client that stops sending it.
-      //
-      // ★★★ 5 SECONDS, MATCHING KIWI'S OWN CLIENT. We sent this at 1 Hz, five times more often
-      // than the browser does for no benefit. Verified against the receiver's own
-      // `kiwisdr.min.js` (2026-07-31):
-      //     window.setInterval(send_keepalive, 5000);                       // main
-      //     setInterval(function(){ ext_send("SET keepalive"); }, 5000);    // extensions
-      //     setInterval(function(){ msg_send('SET keepalive'); … }, 2500);  // queue/monitor
-      //
-      // ★★★ AND IT CORRECTS memory/third_party_receiver_etiquette.md, which claimed our keepalive
-      // "DEFEATS the server's own 'are you still there' kick". IT DOES NOT — the official client
-      // sends it unconditionally on a timer as well, so this is transport liveness, not presence.
-      // Kiwi's inactivity timeout is driven by something else (user commands, and the rn/rt
-      // counter its client watches). That claim was the entire reason the app grew its own
-      // 30-minute hand-back; the premise was false.
-      // ★ Do NOT make this activity-driven. Stopping it gets us kicked, and it would make us
-      // behave UNLIKE the reference client on somebody else's receiver — the opposite of the
-      // etiquette we are trying to keep.
-      this.keepalive = setInterval(() => {
-        this.sndSend('SET keepalive');
-        this.wfSend('SET keepalive');
-      }, 5000);
-
+      this._done = () => { if (!settled) { settled = true; resolve(); } };
+      this._fail = (e: any) => { if (!settled) { settled = true; reject(e); } };
       // Resolve once audio params are away (we're effectively connected); guard
-      // with a timeout so a silent server still rejects.
-      const t = setTimeout(() => fail(new Error('KiwiSDR handshake timed out')), 12000);
-      this._onConnected = () => { clearTimeout(t); this.cb.onConnect(); done(); };
+      // with a timeout so a silent server still rejects. Re-armed if the URL-dialect
+      // probe restarts the handshake, so the retry gets a full budget of its own.
+      this.armHandshakeTimeout();
+      this._onConnected = () => {
+        if (this.handshakeTimer) { clearTimeout(this.handshakeTimer); this.handshakeTimer = null; }
+        this.cb.onConnect(); this._done?.();
+      };
+      this.openSockets();
     });
+  }
+
+  private _done: (() => void) | null = null;
+  private _fail: ((e: any) => void) | null = null;
+  private handshakeTimer: ReturnType<typeof setTimeout> | null = null;
+  private armHandshakeTimeout(): void {
+    if (this.handshakeTimer) clearTimeout(this.handshakeTimer);
+    this.handshakeTimer = setTimeout(() => {
+      this.handshakeTimer = null;
+      this._fail?.(new Error(`${this.label()} handshake timed out`));
+    }, 12000);
+  }
+
+  /** Open (or re-open, after a dialect swap) both sockets and start the keepalive. */
+  private openSockets(): void {
+    const fail = (e: any) => this._fail?.(e);
+    this.wfOpened = false;
+    this.sawServerMsg = false;
+    // Open the SND socket FIRST. The reference client only opens W/F *after*
+    // the SND auth succeeds (kiwi.js: "repeat the auth for the second
+    // websocket … we only get here if the first auth has worked"). Opening
+    // both at once makes the Kiwi drop the SND connection after a few seconds.
+    try {
+      this.sndWs = new (WebSocket as any)(this.url('SND'), null, { headers: { 'User-Agent': KIWI_UA } }) as WebSocket;
+    } catch (e) { fail(e); return; }
+    this.sndWs.binaryType = 'arraybuffer';
+
+    this.sndWs.onopen = () => {
+      this.dbg('SND open');
+      // ★★ '#' MEANS "NO PASSWORD", NOT AN EMPTY STRING. Kiwi's own client:
+      //      pwd = (pwd != '') ? pwd : '#';
+      //      ext_send('SET auth t=' + conn_type + ' p=' + pwd + ipl + reset_s, ws);
+      // We sent `p=` with nothing after it. Verified 2026-07-31 that this alone does NOT fix the
+      // receivers that refuse us after ~10 s — so it is not the cause of that — but behaving
+      // identically to the reference client on someone else's hardware is the whole point of
+      // memory/third_party_receiver_etiquette.md, and an empty field is the sort of thing a
+      // stricter server is entitled to reject.
+      this.sndSend(`SET auth t=kiwi p=${this.password || '#'}`);
+      // Ident goes EARLY, right after auth — a "require name/callsign" server checks it at
+      // connect time, so sending it late (buried in the RX params) means the refusal has
+      // already happened. See kiwiIdent / IdentModal.
+      this.sndSend(`SET ident_user=${this.ident}`);
+      this.sndSend('SERVER DE CLIENT openwebrx.js SND');
+      // RX params (which START the audio stream) — a short tick lets the
+      // server process auth first; also re-asserted on the audio_rate MSG.
+      setTimeout(() => { if (this.started) this.sendRxParams(); }, 150);
+    };
+    this.sndWs.onmessage = (e) => {
+      try {
+        if (typeof e.data === 'string') this.onText(e.data, 'SND');
+        else {
+          const u8 = new Uint8Array(e.data as ArrayBuffer);
+          this.rxBytes += u8.length;
+          this.startRateMeter();
+          this.onBinaryFrame(u8, 'SND');
+        }
+        this.openWf();
+      } catch (err: any) { this.dbg('SND msg err: ' + (err?.message ?? err)); }
+    };
+    // ★ Both of these DEFER to the URL-dialect probe. A wrong prefix surfaces as an error
+    // immediately followed by a close, and failing the promise from either one would reject the
+    // connect before the retry ever ran. canSwapWsPrefix() only holds while the server has said
+    // nothing at all, so a genuine refusal still reports on the first attempt.
+    this.sndWs.onerror = () => {
+      this.dbg('SND error');
+      if (this.canSwapWsPrefix()) return;      // the close that follows drives the retry
+      fail(new Error(`${this.label()} SND socket error`));
+    };
+    this.sndWs.onclose = (ev: any) => {
+      this.dbg('SND close code=' + ev?.code + ' reason=' + ev?.reason);
+      if (this.tryOtherWsPrefix()) return;
+      this.onSocketDrop(ev?.reason ?? '');
+      fail(new Error(`${this.label()} SND closed`));
+    };
+
+    // Open W/F right away too (both share this.ts). The first-SND-MSG gate
+    // (openWf in onmessage) is kept as a no-op fallback via the wfOpened guard.
+    this.openWf();
+
+    // Keepalive on BOTH sockets — Kiwi kicks a client that stops sending it.
+    //
+    // ★★★ 5 SECONDS, MATCHING KIWI'S OWN CLIENT. We sent this at 1 Hz, five times more often
+    // than the browser does for no benefit. Verified against the receiver's own
+    // `kiwisdr.min.js` (2026-07-31):
+    //     window.setInterval(send_keepalive, 5000);                       // main
+    //     setInterval(function(){ ext_send("SET keepalive"); }, 5000);    // extensions
+    //     setInterval(function(){ msg_send('SET keepalive'); … }, 2500);  // queue/monitor
+    //
+    // ★★★ AND IT CORRECTS memory/third_party_receiver_etiquette.md, which claimed our keepalive
+    // "DEFEATS the server's own 'are you still there' kick". IT DOES NOT — the official client
+    // sends it unconditionally on a timer as well, so this is transport liveness, not presence.
+    // Kiwi's inactivity timeout is driven by something else (user commands, and the rn/rt
+    // counter its client watches). That claim was the entire reason the app grew its own
+    // 30-minute hand-back; the premise was false.
+    // ★ Do NOT make this activity-driven. Stopping it gets us kicked, and it would make us
+    // behave UNLIKE the reference client on somebody else's receiver — the opposite of the
+    // etiquette we are trying to keep.
+    this.stopKeepalive();          // a dialect retry must not stack a second one
+    this.keepalive = setInterval(() => {
+      this.sndSend('SET keepalive');
+      this.wfSend('SET keepalive');
+    }, 5000);
+  }
+
+  /** ★★★ NO DIRECTORY HAS A WEB-888 TYPE, so detecting the fork from its landing page fixes the
+   *  ADD-SERVER path and nothing else. Checked 2026-08-03: Receiverbook's feed emits exactly
+   *  three receiver types (`KiwiSDR`, `OpenWebRX`, `WebSDR`) and kiwisdr.com's list is Kiwis by
+   *  definition — so a Web-888 listed anywhere is listed as a KiwiSDR, and rightly, because that
+   *  is what it is compatible with. fetchKiwiList() now reads each row's `sw_version` and tags
+   *  `Web888_*` correctly, but Receiverbook publishes no such field and older/renamed firmware
+   *  will slip through. This probe is what catches the remainder.
+   *
+   *  A wrong prefix fails in ONE unmistakable way: the server closes having sent NOTHING. RaspSDR
+   *  returns NULL from rx_server_websocket before a byte goes out (rx_server.cpp:280). Every real
+   *  rejection — badp, too_busy, ip_limit, owner block — arrives AFTER a MSG or two, because the
+   *  server has to admit us before it can refuse us. So `sawServerMsg` is the discriminator, and
+   *  it is the reason this cannot swallow a genuine refusal.
+   *
+   *  ★★ THE ASYMMETRY IS REAL, AND IT IS NOT WHAT THE SOURCE SUGGESTS. Reading upstream, the
+   *  non-`ws/` branch looks like a failure path — it sets `isWebSocket = false`. It is not:
+   *  grep the file and that variable is only ever PRINTED, never branched on. Measured 2026-08-03
+   *  against two v1.902 receivers (kiwisdr.areg.org.au, sdr.ironstonerange.com): both stream
+   *  perfectly over the bare `kiwi/<ts>/…` path, so `kiwi/` is in fact the MORE compatible of the
+   *  two and the web888→kiwi direction of this swap is close to dead code.
+   *  ★ DO NOT therefore collapse the two and send `kiwi/` to everything. `ws/kiwi/` is what the
+   *    reference client sends and what upstream documents, and looking exactly like the reference
+   *    client on someone else's receiver is the standing rule in this file (see KIWI_UA, the `p=#`
+   *    note, the 5 s keepalive). Two hosts out of 839 is not a mandate to diverge from it — and
+   *    the retry below already costs a wrong guess only one socket.
+   *
+   *  ★ ONCE per connect, and only before the first MSG. Retrying a receiver in a loop is exactly
+   *    what gets an address blacklisted — see memory/third_party_receiver_etiquette.md.
+   *  ★ A FRESH `ts`. The tstamp keys the connection server-side; reusing the one the dying socket
+   *    owns risks matching that half-closed conn instead of allocating a new channel.
+   */
+  private canSwapWsPrefix(): boolean {
+    return this.started && !this.prefixSwapped && !this.sawServerMsg;
+  }
+  private tryOtherWsPrefix(): boolean {
+    if (!this.canSwapWsPrefix()) return false;
+    const was = this.wsPrefix;
+    this.prefixSwapped = true;
+    this.variant = this.variant === 'web888' ? 'kiwi' : 'web888';
+    this.dbg(`closed with no reply on /${was}/ — retrying as ${this.label()} (/${this.wsPrefix}/)`);
+    this.stopKeepalive();
+    this.closeSocket('sndWs');
+    this.closeSocket('wfWs');
+    this.ts = Date.now();
+    this.armHandshakeTimeout();     // the retry gets a full handshake budget
+    this.openSockets();
+    return true;
   }
 
   /** When audio actually started flowing this session — for the short-session test in
@@ -368,7 +480,15 @@ export class KiwiAdapter implements SDRBackend {
       } catch (err: any) { this.dbg('WF msg err: ' + (err?.message ?? err)); }
     };
     this.wfWs.onerror = () => { this.dbg('WF error'); };
-    this.wfWs.onclose = (ev: any) => { this.dbg('WF close code=' + ev?.code + ' reason=' + ev?.reason); this.onSocketDrop(ev?.reason ?? ''); };
+    this.wfWs.onclose = (ev: any) => {
+      this.dbg('WF close code=' + ev?.code + ' reason=' + ev?.reason);
+      // ★ Both sockets carry the same wrong prefix, so W/F is closed by the server too — and it
+      // often loses the race. Tearing down here would set started=false and kill the retry before
+      // SND's close ever reached tryOtherWsPrefix(). Let SND drive it; this close means nothing
+      // until the server has actually spoken to us.
+      if (this.canSwapWsPrefix()) return;
+      this.onSocketDrop(ev?.reason ?? '');
+    };
   }
 
   // ── binary frame dispatch ───────────────────────────────────────────────
@@ -376,6 +496,9 @@ export class KiwiAdapter implements SDRBackend {
   // 3-char ASCII tag ('MSG'/'SND'/'W/F'/'EXT'). MSG carries the text control
   // plane (audio_rate, sample_rate, badp, too_busy …) — it is NOT a text frame.
   private onBinaryFrame(buf: Uint8Array, stream: 'SND' | 'W/F'): void {
+    // The server has spoken → the URL dialect was right, so stop second-guessing it. From here a
+    // close is a real event and must be reported as one, never retried at a different URL.
+    this.sawServerMsg = true;
     if (buf.length < 3) return;
     const tag = String.fromCharCode(buf[0], buf[1], buf[2]);
     if (tag === 'MSG') {
@@ -392,6 +515,7 @@ export class KiwiAdapter implements SDRBackend {
 
   // ── text (MSG) ───────────────────────────────────────────────────────────
   private onText(data: string, stream: 'SND' | 'W/F'): void {
+    this.sawServerMsg = true;                      // see onBinaryFrame
     this.dbg(stream + ' rx: ' + data.slice(0, 120));
     if (!data.startsWith('MSG')) return;            // CLI / other — ignore
     const body = data.slice(4);                     // skip "MSG "
@@ -902,6 +1026,9 @@ export class KiwiAdapter implements SDRBackend {
   destroy(): void {
     this.started = false;
     this.stopKeepalive();
+    // The handshake timeout is a field now (the dialect retry re-arms it), so it has to be
+    // cleared here or a torn-down adapter still rejects its dead promise 12 s later.
+    if (this.handshakeTimer) { clearTimeout(this.handshakeTimer); this.handshakeTimer = null; }
     if (this.audioStarted) { Vibe?.stopExternalAudio?.(); this.audioStarted = false; this.lastDecoderFreq = -1; }
     this.closeSocket('sndWs');
     this.closeSocket('wfWs');
@@ -970,12 +1097,19 @@ export class KiwiAdapter implements SDRBackend {
         // "only allows its own web interface" block, and compatibility mode is exactly the fix,
         // so say so in plain English rather than dumping the raw protocol string on the user.
         const handshakeBlock = /sec-websocket|websocket|handshake|redirect|30[12]|\b40[13]\b|forbidden|moved/i.test(reason);
+        // ★★ NAME THE RADIO IN FRONT OF THEM. Every one of these read "This KiwiSDR…", which is
+        // wrong on a Web-888 — and worse than wrong when the receiver is the user's own, because
+        // the reasonless-close branch below accuses its owner of blocking us. That branch is
+        // exactly what a mismatched URL dialect used to look like (see tryOtherWsPrefix); now
+        // that we retry the other dialect first, reaching here really does mean the receiver hung
+        // up on us — but it still has to say WHICH receiver.
+        const what = this.label();
         this.cb.onError(
           handshakeBlock
-            ? 'This KiwiSDR wouldn’t open a data connection for the app — it sent us to its own web page instead. Many owners only allow their own web interface. Use “Open in compatibility mode” below to listen via the receiver’s web page, or try another KiwiSDR.'
+            ? `This ${what} wouldn’t open a data connection for the app — it sent us to its own web page instead. Many owners only allow their own web interface. Use “Open in compatibility mode” below to listen via the receiver’s web page, or try another receiver.`
           : reason
-            ? `This KiwiSDR closed the connection: “${reason}”. Try another KiwiSDR, or use UberSDR or OpenWebRX.`
-            : 'This KiwiSDR closed the connection without giving a reason — most likely it only allows its own web page and blocks apps like VibeSDR. Try another KiwiSDR, or use UberSDR or OpenWebRX.');
+            ? `This ${what} closed the connection: “${reason}”. Try another receiver, or use UberSDR or OpenWebRX.`
+            : `This ${what} closed the connection without giving a reason — most likely it only allows its own web page and blocks apps like VibeSDR. Try another receiver, or use UberSDR or OpenWebRX.`);
       }
     } else if (this.streamedFor() < 20000 && !this.errorShown) {
       // ★ ADMITTED, STREAMED, THEN CUT IN SECONDS — a receiver enforcing a limit, not a lost link.
@@ -1000,10 +1134,10 @@ export class KiwiAdapter implements SDRBackend {
       // happened to be 0. An unexplained boot is what made this maddening to diagnose; an explained
       // one is just a busy receiver.
       if (this._tooBusyClose()) {
-        this.cb.onError('This KiwiSDR reported that it is too busy and closed the session. Its channels are in use, or the owner reserves them — it is the receiver’s decision, not a problem with your connection. Try another, or come back later.');
+        this.cb.onError(`This ${this.label()} reported that it is too busy and closed the session. Its channels are in use, or the owner reserves them — it is the receiver’s decision, not a problem with your connection. Try another, or come back later.`);
         return;
       }
-      this.cb.onError('This KiwiSDR accepted us and then closed the session after a few seconds, without saying why. That is the receiver’s decision, not a problem with your connection — owners variously cap daily listening time per address, allow only their own web page, or reserve slots. Try another KiwiSDR; this one may let you back in later.');
+      this.cb.onError(`This ${this.label()} accepted us and then closed the session after a few seconds, without saying why. That is the receiver’s decision, not a problem with your connection — owners variously cap daily listening time per address, allow only their own web page, or reserve slots. Try another receiver; this one may let you back in later.`);
     } else {
       // Was streaming for a while, then dropped — a genuine mid-session loss.
       this.cb.onServerLost?.();

--- a/src/services/SDRBackend.ts
+++ b/src/services/SDRBackend.ts
@@ -14,7 +14,9 @@
 
 import type { SDRStatus, SDRMode, SDRCallbacks } from './UberSDRClient';
 
-export type BackendKind = 'ubersdr' | 'kiwi' | 'owrx' | 'fmdx';
+// 'web888' is KiwiAdapter too — a Web-888 / RaspSDR speaks the Kiwi protocol at a different URL,
+// nothing more. See isKiwiProtocol() in sdrTypes; anything gating Kiwi behaviour must accept both.
+export type BackendKind = 'ubersdr' | 'kiwi' | 'web888' | 'owrx' | 'fmdx';
 
 /** FM-DX transmitter identification (from the server's maps.fmdx.org lookup).
  *  Distances/azimuths are relative to the SERVER's QTH, not the listener. */

--- a/src/services/UberSDRAdapter.ts
+++ b/src/services/UberSDRAdapter.ts
@@ -164,7 +164,10 @@ export function createBackend(
   switch (kind) {
     case 'ubersdr': return new UberSDRAdapter(baseUrl, uuid, callbacks, password, local);
     case 'owrx':    return new OwrxAdapter(baseUrl, uuid, callbacks);
-    case 'kiwi':    return new KiwiAdapter(baseUrl, uuid, callbacks, password);
+    // Same adapter for both Kiwi dialects — only the WebSocket path differs, and it self-corrects
+    // if the guess was wrong (KiwiAdapter.tryOtherWsPrefix).
+    case 'kiwi':    return new KiwiAdapter(baseUrl, uuid, callbacks, password, 'kiwi');
+    case 'web888':  return new KiwiAdapter(baseUrl, uuid, callbacks, password, 'web888');
     case 'fmdx':    return new FmdxAdapter(baseUrl, uuid, callbacks);
     default: throw new Error(`backend '${kind}' not implemented`);
   }

--- a/src/services/directories.ts
+++ b/src/services/directories.ts
@@ -17,7 +17,7 @@ export interface DirectoryMeta {
   name:  string;
   desc:  string;
   /** which backends this directory yields — drives the footer logo/labels. */
-  kinds: ('ubersdr' | 'owrx' | 'kiwi' | 'fmdx' | 'spyserver')[];
+  kinds: ('ubersdr' | 'owrx' | 'kiwi' | 'web888' | 'fmdx' | 'spyserver')[];
 }
 
 export const DIRECTORIES: DirectoryMeta[] = [
@@ -155,7 +155,14 @@ async function fetchKiwiList(lat?: number, lon?: number): Promise<SDRInstance[]>
         distance: (lat != null && lon != null && glat != null && glon != null)
           ? haversineKm(lat, lon, glat, glon) : null,
         bestSnr: snr.length ? Math.max(...snr) : null,
-        serverType: 'kiwi',
+        // ★ The row NAMES the firmware, so use it rather than assuming the parent product: a
+        //   Web-888 reports `sw_version: "Web888_v2026.609"` where a Kiwi reports
+        //   `"KiwiSDR_v1.902"`. The two want different WebSocket URLs (see isKiwiProtocol), and
+        //   getting it right here saves the adapter a failed socket and a retry round-trip.
+        //   ★★ This directory has no `type` field to tell them apart — sw_version is the only
+        //      signal in the feed, and Receiverbook does not publish even that, which is why
+        //      KiwiAdapter still needs its own fallback probe.
+        serverType: /web[_-]?888/i.test(String(r.sw_version ?? '')) ? 'web888' : 'kiwi',
       });
     });
 }

--- a/src/services/instancesApi.ts
+++ b/src/services/instancesApi.ts
@@ -15,7 +15,7 @@ export interface SDRInstance {
   countryCode:   string | null;  // ISO 3166-1 alpha-2 (directory country_code)
   distance:      number | null;   // km, populated when user location is known
   bestSnr:       number | null;   // best band-condition SNR across all bands
-  serverType?:   'ubersdr' | 'owrx' | 'kiwi' | 'fmdx' | 'spyserver';  // directory-tagged backend (skips re-detect)
+  serverType?:   'ubersdr' | 'owrx' | 'kiwi' | 'web888' | 'fmdx' | 'spyserver';  // directory-tagged backend (skips re-detect)
   // SpyServer only: the protocol is host:port, not a URL. `url` carries
   // spyserver://host:port so the rest of the list plumbing (keys, favourites)
   // keeps working unchanged.

--- a/src/services/sdrTypes.ts
+++ b/src/services/sdrTypes.ts
@@ -51,7 +51,52 @@ export async function checkConnection(_url: string, _password?: string): Promise
   return { allowed: true, passwordRequired: false };
 }
 
-export type ServerType = 'ubersdr' | 'kiwi' | 'owrx';
+export type ServerType = 'ubersdr' | 'kiwi' | 'web888' | 'owrx';
+
+/** ★★★ WEB-888 SPEAKS KIWI, BUT NOT AT THE SAME URL — and that one difference is the whole
+ *  reason a Web-888 could not be connected to at all, on either the KiwiSDR or the OpenWebRX
+ *  setting, until 2026-08-03.
+ *
+ *  A Web-888 (and anything else built on RaspSDR/server, e.g. the RX-888 boxes) runs a FORK of
+ *  the KiwiSDR server taken before jks-prv moved to the mongoose 7 API. Upstream Kiwi now needs
+ *  a `ws/` marker on the URL so its web server can tell a WebSocket upgrade from a plain GET —
+ *  its own source says so (Beagle_SDR_GPS/rx/rx_server.cpp):
+ *
+ *      // The new mongoose API requires something in the URL to distinguish web socket
+ *      // connections from normal HTTP transfers. … We prefix web socket URLs with "ws/".
+ *      if ((n=sscanf(uri_ts, "ws/%8m[^/]/%lld/%256m[^\?]", …)) == 3) isWebSocket = true;
+ *
+ *  The fork never gained that branch. RaspSDR/server/rx/rx_server.cpp accepts ONLY:
+ *
+ *      kiwi/<ts>/<stream>      no_wf/<ts>/<stream>      <ts>/<stream>   (kiwirecorder)
+ *      else printf("bad URI_TS format\n"); return NULL;      // ← line 280, and our fate
+ *
+ *  So `/ws/kiwi/<ts>/SND` hit that else, the server returned NULL, and the socket was closed
+ *  with code 1006 and ZERO bytes sent. VERIFIED against a live Web-888 (sw_version
+ *  Web888_v2026.609) on 2026-08-03: `/ws/kiwi/…` closes instantly; `/kiwi/…` completes the
+ *  handshake and streams both audio and waterfall.
+ *
+ *  ★★ AND THE ERROR MESSAGE BLAMED THE OWNER. A reasonless close is what a Kiwi that only
+ *  allows its own web page looks like, so onSocketDrop told the user this receiver "blocks apps
+ *  like VibeSDR" — about their OWN radio, sitting on their own desk. A wrong diagnosis is worse
+ *  than none: it sends someone to argue with a restriction that does not exist.
+ *
+ *  ★ 'openwebrx' IS NOT THE ANSWER EITHER, however much the lineage suggests it. Kiwi's *web UI*
+ *  was forked from OpenWebRX years ago — that is why our own client string is
+ *  `SERVER DE CLIENT openwebrx.js` and why the landing page still says "openwebrx". The modern
+ *  OpenWebRX+ WIRE protocol shares nothing with it: one socket at `/ws/`, JSON control plane.
+ *  OwrxAdapter cannot talk to a Web-888 and never could.
+ */
+export function isKiwiProtocol(t?: string | null): boolean {
+  return t === 'kiwi' || t === 'web888';
+}
+
+/** How each Kiwi-protocol dialect names itself to the user. Keep these in step with
+ *  PROTO_LABEL in InstancePickerScreen — a Web-888 owner told "KiwiSDR closed the
+ *  connection" has to guess that the app means their radio. */
+export function kiwiFamilyLabel(t?: string | null): string {
+  return t === 'web888' ? 'Web-888' : 'KiwiSDR';
+}
 
 /** Everything the "Custom server" box can reach. The HTTP kinds are what
  *  detectServerType() can sniff; the raw-TCP kinds (rtl_tcp, SpyServer) speak no
@@ -61,7 +106,7 @@ export type BackendType = ServerType | 'fmdx' | 'vibeserver' | 'rtltcp' | 'spyse
 
 /** Default port per backend, used to guess a bare host and to prefill the form. */
 export const DEFAULT_PORT: Record<BackendType, number> = {
-  ubersdr: 8073, kiwi: 8073, owrx: 8073, fmdx: 8080,
+  ubersdr: 8073, kiwi: 8073, web888: 8073, owrx: 8073, fmdx: 8080,
   vibeserver: 48000, rtltcp: 1234, spyserver: 5555,
 };
 
@@ -74,8 +119,23 @@ export async function detectServerType(url: string): Promise<BackendType | null>
   // Manual AbortController + setTimeout — AbortSignal.timeout() isn't reliably
   // available in Android's Hermes runtime and throws before the fetch even runs,
   // which used to make detection fail → default to ubersdr → 404 on OWRX servers.
-  const ctrl = new AbortController();
-  const timer = setTimeout(() => ctrl.abort(), 5000);
+  //
+  // ★★★ ONE BUDGET PER REQUEST, NOT ONE FOR THE WHOLE FUNCTION. A single shared controller meant
+  // the VibeServer identity probe could spend the ENTIRE 5 s and then abort the landing-page fetch
+  // — the one that actually identifies the server — before it had sent a byte. Detection then
+  // returned null: "nothing there", for a receiver answering in half a second.
+  //
+  // ★★ And it is not hypothetical. Measured 2026-08-03: a KiwiSDR does not 404 an unknown path,
+  // it simply NEVER ANSWERS. `GET /vibeserver.json` against kiwisdr.areg.org.au:8073 and
+  // sdr.ironstonerange.com:8073 hangs open indefinitely, while `GET /` on both returns in ~0.6 s.
+  // So the shared timer made the sniff unreachable on the whole KiwiSDR family — including
+  // Web-888, whose auto-detection this fix is what makes reliable.
+  const withTimeout = async (u: string): Promise<Response> => {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), 5000);
+    try { return await fetch(u, { signal: ctrl.signal }); }
+    finally { clearTimeout(timer); }
+  };
   try {
     // ★★ ASK, DON'T SNIFF — VibeServer is the one protocol we own both ends of,
     // so it identifies itself instead of being guessed at from page prose.
@@ -87,14 +147,14 @@ export async function detectServerType(url: string): Promise<BackendType | null>
     // ubersdr default every single time. /vibeserver.json is served regardless
     // of that toggle.
     try {
-      const idr = await fetch(base + '/vibeserver.json', { signal: ctrl.signal });
+      const idr = await withTimeout(base + '/vibeserver.json');
       if (idr.ok) {
         const id = await idr.json();
         if (id && id.server === 'vibeserver') return 'vibeserver';
       }
     } catch { /* not a VibeServer, or older than this endpoint — fall through */ }
 
-    const r = await fetch(base + '/', { signal: ctrl.signal });
+    const r = await withTimeout(base + '/');
     const body = (await r.text()).toLowerCase();
     // ORDER MATTERS, and every rule here exists because a later backend's page
     // contains an earlier one's marker:
@@ -118,14 +178,22 @@ export async function detectServerType(url: string): Promise<BackendType | null>
     // no reason to appear on anyone else's.
     if (body.includes('vibeserver')) return 'vibeserver';
     if (body.includes('ubersdr')) return 'ubersdr';
+    // Web-888 / RaspSDR BEFORE Kiwi, for the same reason UberSDR goes before Kiwi above: it IS a
+    // Kiwi fork, so its page carries every Kiwi marker (`kiwi_util`, `data-type=kiwi`, and
+    // "openwebrx" too) and matched as plain 'kiwi' — which then used the upstream `ws/` URL and
+    // could not connect at all. See isKiwiProtocol() for why the URL differs.
+    // ★ Match the BRANDING, which is the only thing that separates the fork from its parent: the
+    //   firmware serves its own logo (`gfx/web-888.51x60.png`) and links rx-888.com. Verified on a
+    //   live Web-888, 2026-08-03. `raspsdr` covers the upstream project's own builds.
+    // ★★ These are hyphen-optional on purpose — the product is written "Web-888" and "web888"
+    //    (its own sw_version is `Web888_v2026.609`) about equally often.
+    if (/web-?888|rx-?888|raspsdr/.test(body)) return 'web888';
     if (/kiwisdr|kiwi sdr|\/kiwi\/|kiwi_util|owrx_ws_open/.test(body)) return 'kiwi';
     if (body.includes('openwebrx')) return 'owrx';
     if (/fm-dx|fmdx/.test(body)) return 'fmdx';
     return 'ubersdr';            // reachable but unidentifiable → assume ubersdr
   } catch {
     return null;                // couldn't reach — caller keeps any known type
-  } finally {
-    clearTimeout(timer);
   }
 }
 
@@ -257,26 +325,49 @@ export async function fetchOccupancy(baseUrl: string, timeoutMs = 2500):
   finally { clearTimeout(t); }
 }
 
+/** What answered, and WHERE. */
+export interface ProbeResult {
+  type: BackendType;
+  /** ★★★ THE ADDRESS THAT ACTUALLY ANSWERED — connect to THIS, not to what the user typed.
+   *  probeServer tries several candidate URLs and used to throw away which one worked, returning
+   *  only the type. Every caller then connected to its own guess instead, so detection succeeding
+   *  on one address and the connection being made to another was a silent, routine outcome:
+   *
+   *    - typed `web-888.local` + `8073` in the separate Port box → detection found it at
+   *      `http://web-888.local:8073`, the connect went to `http://web-888.local` (port 80) and
+   *      died with "connection refused". Reported 2026-08-03 against a Web-888; the favourite it
+   *      saved was typed CORRECTLY, which is what made it look like a Web-888 bug rather than an
+   *      address bug — tapping the saved row worked, because that path rebuilds the URL.
+   *    - an https-only receiver on a custom port: detected over https, connected over http.
+   *
+   *  Returning the winning URL makes "what we probed" and "what we connect to" the same string
+   *  by construction, which is the only way this class of bug stays fixed. */
+  url: string;
+}
+
 export async function probeServer(
   host: string, port: number, hint?: BackendType | null, baseUrl?: string,
-): Promise<BackendType | null> {
-  if (hint) return hint;
+): Promise<ProbeResult | null> {
+  const fallbackUrl = baseUrl || `http://${host}:${port}`;
+  // An explicit choice is not probed at all, so the caller's address is all we know.
+  if (hint) return { type: hint, url: fallbackUrl };
 
   // ★ A URL WINS WHEN WE HAVE ONE. A receiver in a subfolder does not answer at the root, so
   // probing `host:port` alone reports "nothing there" for a server that is plainly running.
   if (baseUrl) {
     const t = await detectServerType(baseUrl);
-    if (t) return t;
+    if (t) return { type: t, url: baseUrl };
   }
 
   const authority = `${host}:${port}`;
   for (const scheme of ['https', 'http'] as const) {
-    const t = await detectServerType(`${scheme}://${authority}`);
-    if (t) return t;
+    const url = `${scheme}://${authority}`;
+    const t = await detectServerType(url);
+    if (t) return { type: t, url };
   }
 
   // No HTTP answered. Raw-TCP backends can only be inferred from the port.
-  if (port === DEFAULT_PORT.rtltcp) return 'rtltcp';
-  if (port === DEFAULT_PORT.spyserver) return 'spyserver';
+  if (port === DEFAULT_PORT.rtltcp) return { type: 'rtltcp', url: fallbackUrl };
+  if (port === DEFAULT_PORT.spyserver) return { type: 'spyserver', url: fallbackUrl };
   return null;                  // unreachable, or raw TCP on a port we can't name
 }

--- a/website/index.html
+++ b/website/index.html
@@ -576,7 +576,7 @@
       Native adapters for the major SDR networks, for local USB hardware, and for your own server — all behind the same dial and the same waterfall. Change receiver and nothing about the app changes with it.
     </p>
     <ul class="ticks" style="margin-top:22px">
-      <li><b>UberSDR · OpenWebRX · KiwiSDR</b> — native clients for the big shared&#8209;receiver networks, with a directory to find one near you.</li>
+      <li><b>UberSDR · OpenWebRX · KiwiSDR · Web&#8209;888</b> — native clients for the big shared&#8209;receiver networks, with a directory to find one near you.</li>
       <li><b>FM&#8209;DX Webserver</b> — the worldwide network of shared FM tuners. Station names, RadioText and distances, in stereo.</li>
       <li><b>RTL&#8209;SDR over USB</b> — plug a dongle into an Android phone or reach a networked rtl_tcp. VibeSDR demodulates the raw IQ itself.</li>
       <li><b>SpyServer · rtl_tcp</b> — the standard network protocols, spoken natively.</li>


### PR DESCRIPTION
A **Web-888** is KiwiSDR-compatible, but VibeSDR couldn't talk to one on either existing setting — **KiwiSDR** failed instantly, and **OpenWebRX** was never going to work. Worse, the app blamed the receiver's owner: a reasonless close is exactly what a Kiwi that only allows its own web page looks like, so `onSocketDrop` told people their own radio was blocking apps like VibeSDR.

## The cause is one string

A Web-888 runs [RaspSDR](https://github.com/RaspSDR/server), a fork of the KiwiSDR server taken before upstream moved to the mongoose 7 API. That move added a `ws/` marker to the WebSocket path so the server could tell a socket upgrade from a plain GET — upstream's own source says so:

```c
// The new mongoose API requires something in the URL to distinguish web socket
// connections from normal HTTP transfers. … We prefix web socket URLs with "ws/".
if ((n=sscanf(uri_ts, "ws/%8m[^/]/%lld/%256m[^\?]", …)) == 3) isWebSocket = true;
```

The fork never gained that branch. `RaspSDR/server/rx/rx_server.cpp` accepts only:

```c
kiwi/<ts>/<stream>    no_wf/<ts>/<stream>    <ts>/<stream>   // kiwirecorder
else printf("bad URI_TS format\n"); return NULL;             // line 280, and our fate
```

So `/ws/kiwi/<ts>/SND` hit that `else`, the server returned NULL, and the socket closed with **zero bytes sent**.

`openwebrx` is not the answer either, however much the lineage suggests it. Kiwi's *web UI* was forked from OpenWebRX years ago — that's why our client string is `SERVER DE CLIENT openwebrx.js` and why the landing page still says "openwebrx". The modern OpenWebRX+ *wire* protocol shares nothing with it: one socket at `/ws/`, JSON control plane. `OwrxAdapter` cannot talk to a Web-888 and never could.

## What this adds

- **Web-888 is its own choice** in the custom-server box, next to KiwiSDR. Same `KiwiAdapter`; only the path prefix differs.
- **Auto-detect recognises one** from its own branding (it serves `gfx/web-888.png` and links rx-888.com), checked *before* the Kiwi rule since a Web-888's page carries every Kiwi marker. The kiwisdr.com feed is also read more carefully, so a listed unit is tagged from its `sw_version` (`Web888_v…` vs `KiwiSDR_v…`).
- **It self-corrects anyway.** A receiver that closes having said *nothing* is retried once at the other path. That's the one thing a wrong URL looks like and a refusal never does — a server has to admit you before it can throw you out — so a genuine refusal still reports on the first attempt. This is what makes directory-listed Web-888s reachable, because **no directory carries the type**: Receiverbook emits only `KiwiSDR`/`OpenWebRX`/`WebSDR`.
- **Every "This KiwiSDR…" message now names the receiver actually connected to.** Telling someone their Web-888 is blocking them is worse than saying nothing.
- **VibeSDR Jr gets the same support**, and needed it independently of the new hardware: favourites sync between devices and `CloudSyncEngine` mapped an unknown `serverType` to `.ubersdr`, so a Web-888 saved on the phone would arrive on the wrist as the wrong protocol entirely.

## Three bugs found testing this on real hardware — none Web-888-specific

1. **Auto-detect was broken for the whole KiwiSDR family.** Identifying a typed address made two requests on one shared 5 s budget, and the first — the VibeServer identity check — never returns on a Kiwi: that server doesn't refuse an unknown path, it simply never answers (`Headers Timeout Error`). The budget was gone before the request that actually identifies the receiver could start, so every Kiwi-family address reported "nothing there" while answering `GET /` in half a second. Each request now has its own timeout.
2. **Adding a server by host + Port field connected to port 80.** The address was parsed without the port, so the port was right everywhere except in the address dialled. Detection still found the receiver and saved a correctly-typed favourite, which disguised it — tapping the saved row rebuilt the address and worked first time. Address and port now come out of a single parse and can't disagree; a port written into the host field still wins.
3. **Probing discarded *which* address answered**, so identifying a receiver at one address and connecting to another was routine. The same fault would have sent an https-only receiver on a custom port a plain-http connection. `probeServer` now returns the URL that answered, and that's what gets connected to.

Also: the Custom URL box's example now shows a port (`sdr.example.com:8073`). Without one it read as hostname-only, which resolves to port 80 — where no receiver listens.

## Verification

- **Live Web-888** (`Web888_v2026.609`), driving the real `KiwiAdapter`: audio and waterfall both stream — both when told it's a Web-888 (no retry) and when told it's a KiwiSDR (one silent retry, `closed with no reply on /ws/kiwi/ — retrying as Web-888 (/kiwi/)`).
- **Two public KiwiSDRs** (v1.902, kiwisdr.areg.org.au and sdr.ironstonerange.com): still connect on the first attempt with **no retry**, confirming no regression.
- Detection checked against all three: `web888`, `kiwi`, `kiwi`.
- Built and **used on an iPhone** — which is how bugs 2 and 3 surfaced; adapter-level testing could never have found them.
- `tsc --noEmit` clean.

⚠️ **VibeSDR Jr is compile-verified but not run.** It builds cleanly for watchOS device (so the new enum case type-checks against every exhaustive switch), but I couldn't install it: my watch is on watchOS 27 beta and Xcode 26.6 ships only watchOS 26.5, so the developer disk image won't mount — and the watchOS simulator can't link Jr's device-only `libopus.a`. Worth a run on your setup before you trust it.

## Review notes

- `KiwiAdapter.ts` reads best with **`git diff -w`**. About 136 of its changed lines are pure re-indentation from extracting `openSockets()` so the dialect retry can re-enter it; the real change is ~150 lines.
- **Known cosmetic limitation:** when the retry corrects a `kiwi` → `web888` guess, the adapter's own messages update but the connection cards still read "KiwiSDR", because that label comes from the route param the user picked rather than from the adapter.
- `ws/kiwi/` is kept as the KiwiSDR default deliberately. Both v1.902 receivers I tested also accept the bare `kiwi/…` path (upstream's `isWebSocket` flag turns out to be only ever *printed*, never branched on), so the two could in principle be collapsed — but `ws/kiwi/` is what the reference client sends, and looking exactly like the reference client on someone else's receiver is the standing rule in that file. Two hosts out of 839 isn't grounds to diverge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
